### PR TITLE
Clams Remote Websocket

### DIFF
--- a/docker_entrypoint.sh
+++ b/docker_entrypoint.sh
@@ -25,6 +25,7 @@ export RPC_TOR_ADDRESS=$(yq e '.rpc-tor-address' /root/.lightning/start9/config.
 export UI_TOR_ADDRESS=$(yq e '.web-ui-tor-address' /root/.lightning/start9/config.yaml)
 export UI_LAN_ADDRESS=$(echo "$UI_TOR_ADDRESS" | sed 's/\.onion/\.local/')
 export REST_TOR_ADDRESS=$(yq e '.rest-tor-address' /root/.lightning/start9/config.yaml)
+export CLAMS_WEBSOCKET_TOR_ADDRESS=$(yq e '.clams-websocket-tor-address' /root/.lightning/start9/config.yaml)
 export WATCHTOWER_TOR_ADDRESS=$(yq e '.watchtower-tor-address' /root/.lightning/start9/config.yaml)
 export TOWERS_DATA_DIR=/root/.lightning/.watchtower
 export REST_LAN_ADDRESS=$(echo "$REST_TOR_ADDRESS" | sed 's/\.onion/\.local/')
@@ -81,6 +82,7 @@ mkdir -p /root/.lightning/public
 echo $PEER_TOR_ADDRESS > /root/.lightning/start9/peerTorAddress
 echo $RPC_TOR_ADDRESS > /root/.lightning/start9/rpcTorAddress
 echo $REST_TOR_ADDRESS > /root/.lightning/start9/restTorAddress
+echo $CLAMS_WEBSOCKET_TOR_ADDRESS > /root/.lightning/start9/clamsRemoteWebsocketTorAddress
 echo $WATCHTOWER_TOR_ADDRESS > /root/.lightning/start9/watchtowerTorAddress
 
 sh /root/.lightning/start9/waitForStart.sh

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -176,14 +176,14 @@ interfaces:
       - http
   websocket:
     name: Websocket
-    description: Websocket Lightning Network interface
+    description: Websocket endpoint for Clams Remote.
     tor-config:
       port-mapping:
-        9736: "9736"
+        7272: "7272"
     lan-config:
-      9736:
+      7272:
         ssl: true
-        internal: 9736
+        internal: 7272
     ui: false
     protocols:
       - tcp

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -175,7 +175,7 @@ interfaces:
       - tcp
       - http
   websocket:
-    name: Websocket
+    name: Clams Websocket
     description: Websocket endpoint for Clams Remote.
     tor-config:
       port-mapping:

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -174,6 +174,21 @@ interfaces:
     protocols:
       - tcp
       - http
+  websocket:
+    name: Websocket
+    description: Websocket Lightning Network interface
+    tor-config:
+      port-mapping:
+        9736: "9736"
+    lan-config:
+      9736:
+        ssl: true
+        internal: 9736
+    ui: false
+    protocols:
+      - tcp
+      - http
+      - ws
 dependencies:
   bitcoind:
     version: ">=0.21.1.2 <27.0.0"

--- a/scripts/procedures/getConfig.ts
+++ b/scripts/procedures/getConfig.ts
@@ -46,6 +46,15 @@ export const [getConfig, setConfigMatcher] = compat.getConfigAndMatcher({
     target: "tor-address",
     interface: "clnrest",
   },
+  "clams-websocket-tor-address": {
+    name: "Websocket Tor Address",
+    description: "The Tor address of the CLN websocket service.",
+    type: "pointer",
+    subtype: "package",
+    "package-id": "c-lightning",
+    target: "tor-address",
+    interface: "websocket",
+  },
   "watchtower-tor-address": {
     name: "TEoS Watchtower API Address",
     description: "The Tor address of the TEoS Watchtower API",
@@ -251,6 +260,12 @@ export const [getConfig, setConfigMatcher] = compat.getConfigAndMatcher({
         type: "boolean",
         name: "Tor Only",
         description: "Only use tor connections.  This increases privacy, at the cost of some performance and reliability.  <b>Default: False</b>",
+        default: false,
+      },
+      "clams_remote_websocket": {
+        type: "boolean",
+        name: "Clams Remote",
+        description: "Enable Core Lightning's websocket interface for Clams Remote.",
         default: false,
       },
       "fee-base": {

--- a/scripts/procedures/getConfig.ts
+++ b/scripts/procedures/getConfig.ts
@@ -265,7 +265,7 @@ export const [getConfig, setConfigMatcher] = compat.getConfigAndMatcher({
       "clams_remote_websocket": {
         type: "boolean",
         name: "Clams Remote",
-        description: "Enable Core Lightning's websocket interface for Clams Remote.",
+        description: "Accept incoming connections on port 7272, allowing Clams Remote to connect to Core Lightning.",
         default: false,
       },
       "fee-base": {

--- a/scripts/procedures/properties.ts
+++ b/scripts/procedures/properties.ts
@@ -89,6 +89,14 @@ export const properties: T.ExpectedExports.properties = async (
   if (
     (await util.exists(effects, {
       volumeId: "main",
+      path: "start9/clamsRemoteWebsocketTorAddress",
+    })) === false
+  ) {
+    return noPropertiesFound;
+  }
+  if (
+    (await util.exists(effects, {
+      volumeId: "main",
       path: "start9/watchtowerTorAddress",
     })) === false
   ) {
@@ -113,6 +121,12 @@ export const properties: T.ExpectedExports.properties = async (
       path: "start9/restTorAddress",
     })
     .then((x) => x.trim());
+  const clamsRemoteWebsocketTorAddress = await effects
+    .readFile({
+      volumeId: "main",
+      path: "start9/clamsRemoteWebsocketTorAddress",
+    })
+    .then((x) => x.trim());
   const watchtowerTorAddress = await effects
     .readFile({
       volumeId: "main",
@@ -133,6 +147,26 @@ export const properties: T.ExpectedExports.properties = async (
       volumeId: "main",
     })
   );
+  const websocketProperties: T.PackagePropertiesV2 = !config.advanced.clams_remote_websocket
+    ? {}
+    : {
+      "Clams Remote Websocket Onion": {
+        type: "string",
+        value: `${clamsRemoteWebsocketTorAddress}`,
+        description: "The onion endpoint for your CLN websocket service for use with Clams Remote.",
+        copyable: true,
+        qr: false,
+        masked: true,
+      },
+      "Clams Remote Websocket Port": {
+        type: "string",
+        value: "7272",
+        description: "The service endpoint for your CLN websocket service for use with Clams Remote.",
+        copyable: true,
+        qr: false,
+        masked: false,
+      }
+    };
 
   const restProperties: T.PackagePropertiesV2 = !config.advanced.plugins.rest
     ? {}
@@ -335,6 +369,15 @@ export const properties: T.ExpectedExports.properties = async (
         value: `${nodeInfo.id}@${peerTorAddress}`,
         description:
           "Share this URI with others so they can add your CLN node as a peer",
+        copyable: true,
+        qr: true,
+        masked: true,
+      },
+      "Clams Remote Websocket URI": {
+        type: "string",
+        value: `${nodeInfo.id}@${clamsRemoteWebsocketTorAddress}:7272`,
+        description:
+          "The URI needed by Clams Remote to connect to Core Lightning's websocket interface.",
         copyable: true,
         qr: true,
         masked: true,

--- a/scripts/procedures/setConfig.ts
+++ b/scripts/procedures/setConfig.ts
@@ -346,6 +346,7 @@ autoclean-succeededpays-age=${config.autoclean["autoclean-succeededpays-age"]}
 autoclean-failedpays-age=${config.autoclean["autoclean-failedpays-age"]}
 autoclean-paidinvoices-age=${config.autoclean["autoclean-paidinvoices-age"]}
 autoclean-expiredinvoices-age=${config.autoclean["autoclean-expiredinvoices-age"]}
+bind-addr=ws::9736
 `;
 }
 const validURI = /^([a-fA-F0-9]{66}@)([^:]+?)(:\d{1,5})?$/m;

--- a/scripts/procedures/setConfig.ts
+++ b/scripts/procedures/setConfig.ts
@@ -292,6 +292,9 @@ function configMaker(alias: Alias, config: SetConfig) {
   const enableCLNRestPlugin = config.advanced.plugins.clnrest
     ? "clnrest-port=3010\nclnrest-host=0.0.0.0\n"
     : "";
+  const enableCLNWebsocket = config.advanced.clams_remote_websocket
+    ? "bind-addr=ws::7272\n"
+    : "";
   const enableClbossPlugin =
     config.advanced.plugins.clboss.enabled === "enabled"
       ? "plugin=/usr/local/libexec/c-lightning/plugins/clboss"
@@ -311,6 +314,7 @@ bitcoin-rpcconnect=${bitcoin_rpc_host}
 bitcoin-rpcport=${bitcoin_rpc_port}
 
 bind-addr=0.0.0.0:9735
+${enableCLNWebsocket}
 announce-addr=${config["peer-tor-address"]}:9735
 proxy={proxy}
 always-use-proxy=${config.advanced["tor-only"]}
@@ -346,7 +350,6 @@ autoclean-succeededpays-age=${config.autoclean["autoclean-succeededpays-age"]}
 autoclean-failedpays-age=${config.autoclean["autoclean-failedpays-age"]}
 autoclean-paidinvoices-age=${config.autoclean["autoclean-paidinvoices-age"]}
 autoclean-expiredinvoices-age=${config.autoclean["autoclean-expiredinvoices-age"]}
-bind-addr=ws::9736
 `;
 }
 const validURI = /^([a-fA-F0-9]{66}@)([^:]+?)(:\d{1,5})?$/m;

--- a/scripts/procedures/setConfig.ts
+++ b/scripts/procedures/setConfig.ts
@@ -292,7 +292,7 @@ function configMaker(alias: Alias, config: SetConfig) {
   const enableCLNRestPlugin = config.advanced.plugins.clnrest
     ? "clnrest-port=3010\nclnrest-host=0.0.0.0\n"
     : "";
-  const enableCLNWebsocket = config.advanced.clams_remote_websocket
+  const enableClamsRemoteWebsocket = config.advanced.clams_remote_websocket
     ? "bind-addr=ws::7272\n"
     : "";
   const enableClbossPlugin =
@@ -314,7 +314,7 @@ bitcoin-rpcconnect=${bitcoin_rpc_host}
 bitcoin-rpcport=${bitcoin_rpc_port}
 
 bind-addr=0.0.0.0:9735
-${enableCLNWebsocket}
+${enableClamsRemoteWebsocket}
 announce-addr=${config["peer-tor-address"]}:9735
 proxy={proxy}
 always-use-proxy=${config.advanced["tor-only"]}


### PR DESCRIPTION
These changes add a websocket interface dedicated to Clams Remote. This interface listens on the LAN and has a dedicated onion address (written to /root/.lightning/start9/clamsRemoteWebsocketTorAddress in container) listening at port 7272 (http for onion). CLN is configured via the '--bind-addr=ws::7272' method. The "Clams Remote Websocket URI" is surfaced as a property. A configuration item to turn off the service is placed under "Advanced->Clams Remote" (off by default).

These changes are needed to support connections by [Clams Remote](https://clams.tech/remote). That team will be submitting the Clams Remote package to Start9 after they have evaluated the solution.

Special thanks to @chrisguida for helping with concept and getting this whole thing started, and for providing excellent advice! This project is the result of the Bitcoin++ Buenos Aires Hackathon project, which won the [Best User Experience prize](https://x.com/farscapian/status/1761514643053232357?s=20). 