### PR TITLE
Update/v24.11.1

### DIFF
--- a/assets/compat/backup-restore.sh
+++ b/assets/compat/backup-restore.sh
@@ -1,5 +1,3 @@
 #!/bin/sh
 
 compat duplicity restore /mnt/backup /root/.lightning
-mkdir -p /root/.lightning/start9
-touch /root/.lightning/start9/restore.yaml

--- a/docker_entrypoint.sh
+++ b/docker_entrypoint.sh
@@ -80,13 +80,6 @@ fi
 mkdir -p /root/.lightning/shared
 mkdir -p /root/.lightning/public
 
-# Don't backup lightningd DB
-if ! [ -e /root/.lightning/.backupignore ]; then
-  echo "Creating .backupignore"
-  touch /root/.lightning/.backupignore
-  echo "/root/.lightning/bitcoin/lightningd.sqlite3" > /root/.lightning/.backupignore
-fi
-
 echo $PEER_TOR_ADDRESS > /root/.lightning/start9/peerTorAddress
 echo $RPC_TOR_ADDRESS > /root/.lightning/start9/rpcTorAddress
 echo $REST_TOR_ADDRESS > /root/.lightning/start9/restTorAddress
@@ -147,12 +140,6 @@ if [ -e /root/.lightning/shared/lightning-rpc ]; then
     rm /root/.lightning/shared/lightning-rpc
 fi
 ln /root/.lightning/bitcoin/lightning-rpc /root/.lightning/shared/lightning-rpc
-
-if [ -e /root/.lightning/start9/restore.yaml ]; then
-  echo "Detected backup restore. Attempting to recover channels using emergency.recover..."
-  lightning-cli emergencyrecover
-  rm /root/.lightning/start9/restore.yaml
-fi
 
 if ! [ -e /root/.lightning/public/access.macaroon ] || ! [ -e /root/.lightning/public/rootKey.key ] ; then
   while ! [ -e /usr/local/libexec/c-lightning/plugins/c-lightning-REST/certs/access.macaroon ] || ! [ -e /usr/local/libexec/c-lightning/plugins/c-lightning-REST/certs/rootKey.key ];

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1,5 +1,5 @@
 id: c-lightning
-version: 24.11.0
+version: 24.11.1
 title: Core Lightning
 license: BSD-MIT
 wrapper-repo: https://github.com/Start9Labs/cln-startos
@@ -7,7 +7,7 @@ upstream-repo: https://github.com/ElementsProject/lightning
 support-site: https://github.com/ElementsProject/lightning/issues
 marketing-site: https://blockstream.com/lightning
 release-notes: |-
-  * Update to CLN 24.11 [Release Notes](https://github.com/ElementsProject/lightning/releases/tag/v24.11)
+  * Update to CLN 24.11.1 [Release Notes](https://github.com/ElementsProject/lightning/releases/tag/v24.11.1)
   * Update clboss to 0.14.1
   * Update Backup Restore to use SCBs rather than lightning db
   * Add experimental xpay plugin

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -9,7 +9,6 @@ marketing-site: https://blockstream.com/lightning
 release-notes: |-
   * Update to CLN 24.11.1 [Release Notes](https://github.com/ElementsProject/lightning/releases/tag/v24.11.1)
   * Update clboss to 0.14.1
-  * Update Backup Restore to use SCBs rather than lightning db
   * Add experimental xpay plugin
 build: ["make"]
 description:

--- a/scripts/procedures/migrations.ts
+++ b/scripts/procedures/migrations.ts
@@ -375,7 +375,7 @@ export const migration: T.ExpectedExports.migration =
         )
       },
     },
-    "24.11.0",
+    "24.11.1",
   );
 
 function generateRandomString(length: number) {


### PR DESCRIPTION
- Updated lightning to 24.11.1
- Reverted backup/restore to use lightningd db rather than SCB `emergencyrecover` until the latter is compatible with LND channels.