### PR TITLE
Fix CLNRest connection string

### DIFF
--- a/scripts/procedures/properties.ts
+++ b/scripts/procedures/properties.ts
@@ -404,7 +404,7 @@ export const properties: T.ExpectedExports.properties = async (
         ? {
             "CLNRest Quick Connect": {
               type: "string",
-              value: `clnrest://${nodeInfo.id}@${clnRestTorAddress}:3010?rune=${clnRestRune}`,
+              value: `clnrest://${clnRestTorAddress}:3010?rune=${clnRestRune}`,
               description:
                 "URI to connect a wallet to Core Lightning's CLNRest interface remotely via Tor",
               copyable: true,


### PR DESCRIPTION
Fixes the connection format string for CLNRest.

The node's pubkey is not required to initiate a REST connection. While there's no formal spec documented for this connection string, inclusion of the node pubkey is not required and not provided by any other implementation that I know of.